### PR TITLE
Updating deployment script, removing health check

### DIFF
--- a/server/railway.toml
+++ b/server/railway.toml
@@ -4,6 +4,4 @@ buildCommand = "echo Building Sanvia!"
 
 [deploy]
 startCommand = "uvicorn main:app --host 0.0.0.0 --port 80"
-healthcheckPath = "/"
-healthcheckTimeout = 100
 restartPolicyType = "never"


### PR DESCRIPTION
- health check consistently throws errors when logs appear to be normal